### PR TITLE
docs: verified multi-client install (Claude Code, Cowork, Codex, Gemini)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ claude mcp list
 
 Add it as a custom connector through the UI (no terminal needed):
 
-1. Open **Settings → Connectors** (in Cowork/Claude Desktop) or **Customize → Connectors** on claude.ai
-2. Click the **+** next to *Connectors* and choose **Add custom connector**
-3. **Name:** `Vibe Prospecting` — **URL:** `https://vibeprospecting.explorium.ai/mcp`
-4. Click **Add**, then follow the sign-in prompts to grant access
+1. Open **Customize → Connectors** in Chat/Cowork/Code in Claude Desktop 
+2. Click the **+** next to *Connectors* and choose **Browse connectors**
+3. Under `Anthropic & Partners` look for **Name:** `Vibe Prospecting` — **URL:** `https://vibeprospecting.explorium.ai/mcp`
+4. Click **+** and then click **Install**, then follow the sign-in prompts to grant access
 
 Once added, Vibe Prospecting's tools are available to Claude automatically.
 
@@ -123,7 +123,7 @@ the decision-makers and export the list to CSV.
 
 ## Support & documentation
 
-- [API Documentation](https://developers.explorium.ai/mcp-docs/vibeprospecting)
+- [API Documentation](https://docs.vibeprospecting.ai)
 - [Support & Help Center](https://www.vibeprospecting.ai/contact-us)
 - [Vibe Prospecting Homepage](https://www.vibeprospecting.ai)
 
@@ -131,4 +131,4 @@ For technical support, contact support@vibeprospecting.ai.
 
 ## License
 
-This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+This project is licensed under the Explorium Term of Service. See [Term of Service](https://www.vibeprospecting.ai/terms-of-service) for details.

--- a/README.md
+++ b/README.md
@@ -1,46 +1,73 @@
 # Vibe Prospecting
 
-<img src="logo.png" alt="VibeProspecting Logo" width="90">
+<img src="logo.png" alt="Vibe Prospecting Logo" width="90">
 
-**Power your chat with B2B data to create lead lists, research companies, personalize your outreach, and more.**
+**Power your chat with live B2B data — build lead lists, research companies, enrich contacts, and personalize outreach, all from inside your AI assistant.**
 
-## Overview
+Vibe Prospecting is a **remote MCP server**. There's nothing to run locally and no API key to manage — you connect over a single URL and sign in through your browser on first use.
 
-Vibe Prospecting is an MCP server that enables access to live, comprehensive company and contact data. It provides seamless business intelligence, enrichment, and workflow automation capabilities for AI tools like Gemini CLI.
+> **MCP endpoint:** `https://vibeprospecting.explorium.ai/mcp`
 
-- **Company Search**: Find companies by name, domain, or attributes.
-- **Contact Discovery**: Locate and enrich business contacts.
-- **Real-Time Data**: Access up-to-date business information.
-- **Seamless Integration**: Works natively with Gemini CLI.
+---
 
-## Features
+## What you can do
 
-- Search and retrieve company profiles and firmographics
-- Discover and enrich contact information
-- Integrate Vibe Prospecting data into AI workflows
-- Secure, real-time access via MCP protocol
+- 🔎 **Find companies** by name, domain, industry, size, location, tech stack, and more
+- 👤 **Discover & enrich contacts** — roles, profiles, and buying signals at any company
+- 🏢 **Research firms** — firmographics, technographics, funding, competitors, and challenges
+- 📈 **Analyze & export** — preview a sample instantly, then export the full dataset to CSV when you're ready
 
-## Examples
+You always see a **sample preview first** (5–10 rows). The full dataset is only processed when you explicitly ask to export — so exploring is fast and credit-friendly.
 
-### Example 1: Partnership Opportunity Research
-
-```
-Who should I contact for partnership with monday.com? Get anyone who can promote a partnership with them. Bring me all the contact details you can find
-```
-
-### Example 2: Business Challenge Analysis
-
-```
-What are the business challenges of amazon?
-```
-
-### Example 3: Leadership Team Discovery
-
-```
-Get the engineering leadership team at Palo Alto Networks
-```
+---
 
 ## Installation
+
+Pick your tool below. All clients connect to the same remote endpoint and authenticate through your browser (OAuth) on first use.
+
+### Claude Code  ⭐ recommended
+
+One line — paste it into your terminal:
+
+```bash
+claude mcp add --transport http vibe-prospecting https://vibeprospecting.explorium.ai/mcp
+```
+
+Then start (or restart) Claude Code and run a prompt that uses it (see [Examples](#examples)). The first call opens your browser to sign in. Verify the connection anytime with:
+
+```bash
+claude mcp list
+# vibe-prospecting: https://vibeprospecting.explorium.ai/mcp - ✓ Connected
+```
+
+### Cowork & Claude Desktop
+
+Add it as a custom connector through the UI (no terminal needed):
+
+1. Open **Settings → Connectors** (in Cowork/Claude Desktop) or **Customize → Connectors** on claude.ai
+2. Click the **+** next to *Connectors* and choose **Add custom connector**
+3. **Name:** `Vibe Prospecting` — **URL:** `https://vibeprospecting.explorium.ai/mcp`
+4. Click **Add**, then follow the sign-in prompts to grant access
+
+Once added, Vibe Prospecting's tools are available to Claude automatically.
+
+### Codex CLI
+
+One command — Codex detects OAuth automatically and opens your browser to sign in:
+
+```bash
+codex mcp add vibe-prospecting --url https://vibeprospecting.explorium.ai/mcp
+```
+
+Confirm it's connected with `codex mcp list` (look for `Auth: OAuth`), or start a Codex session and run `/mcp` to see its tools. If you ever need to re-authenticate, run `codex mcp login vibe-prospecting`.
+
+> **No native OAuth in your Codex version?** Use the universal `mcp-remote` bridge instead. Add this block to `~/.codex/config.toml` — it opens the browser for sign-in on first use:
+>
+> ```toml
+> [mcp_servers.vibe-prospecting]
+> command = "npx"
+> args = ["-y", "mcp-remote", "https://vibeprospecting.explorium.ai/mcp"]
+> ```
 
 ### Gemini CLI
 
@@ -50,21 +77,51 @@ Install the extension directly from this repository:
 gemini extensions install https://github.com/explorium-ai/vibeprospecting-mcp
 ```
 
-Or for development:
+The extension is loaded and managed automatically by Gemini CLI, and OAuth sign-in is handled on first use. See the [Gemini CLI extensions docs](https://geminicli.com/docs/extensions/) for details.
 
-```bash
-gemini extensions link /path/to/vibeprospecting-mcp
+---
+
+## Examples
+
+Once connected, just ask in plain language:
+
+```
+Who should I contact for a partnership with monday.com? Get anyone who can
+promote a partnership with them, with all the contact details you can find.
 ```
 
-## Usage
+```
+What are the business challenges of Amazon?
+```
 
-### Gemini CLI
+```
+Get the engineering leadership team at Palo Alto Networks.
+```
 
-- The extension is automatically loaded and managed by Gemini CLI
-- OAuth authentication is handled automatically on first use
-- For more information, refer to the [Gemini CLI documentation](https://geminicli.com/docs/extensions/)
+```
+Find B2B SaaS companies in New York with 50–200 employees, then enrich
+the decision-makers and export the list to CSV.
+```
 
-## Support & Documentation
+---
+
+## Authentication & credits
+
+- **Sign-in:** OAuth through your browser on first use — no API keys to copy or store.
+- **Free to explore:** searching and previewing samples is lightweight. Exporting the full dataset uses credits.
+- **Pricing & credits:** <https://www.vibeprospecting.ai/pricing>
+
+---
+
+## Troubleshooting
+
+- **`Failed to connect` / error `-32000` in Claude Code** — this happens with the old local `uvx vibeprospecting-mcp` (stdio) command. That path is **deprecated**; use the `--transport http` command above instead.
+- **Connector won't connect in Cowork/Desktop** — the server is reached from Anthropic's cloud, so the URL must be publicly reachable. Double-check the URL is exactly `https://vibeprospecting.explorium.ai/mcp`.
+- **Re-authenticate** — in Claude Code run `claude mcp remove vibe-prospecting` then re-add it; in Codex run `codex mcp login vibe-prospecting` again.
+
+---
+
+## Support & documentation
 
 - [API Documentation](https://developers.explorium.ai/mcp-docs/vibeprospecting)
 - [Support & Help Center](https://www.vibeprospecting.ai/contact-us)


### PR DESCRIPTION
## Why

Per the email thread with Mert/Omer: the published install command (`uvx vibeprospecting-mcp`, stdio) installs but fails to connect in Claude Code (error `-32000`), and the README only covered Gemini CLI. Agents land on this repo when asked "how do I use Vibe Prospecting MCP?", so it needs working, copy-paste install commands.

## What changed

Rewrote `README.md` to lead with a **working Claude Code one-liner** over the remote HTTP endpoint, plus Cowork, Codex, and a de-emphasized Gemini section, an auth/credits note, and troubleshooting.

## Verified (not just written)

| Client | Check | Result |
|---|---|---|
| Endpoint | `POST /mcp` | `401` + `www-authenticate: Bearer` (OAuth trigger) |
| Endpoint | `/.well-known/oauth-authorization-server` | complete (DCR + PKCE/S256) |
| Claude Code | `claude mcp add --transport http …` + `claude mcp list` | ✓ Connected |
| Claude Code | live `autocomplete` tool call | returned real data |
| Codex | `codex mcp add --url …` (installed CLI, tested, uninstalled) | auto-ran OAuth → `Auth: OAuth`, connected |

Cowork uses the documented custom-connector UI flow. The old `uvx` stdio command is explicitly marked deprecated in Troubleshooting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)