### PR TITLE
docs: add Hermes Agent install instructions (PTB-1983)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,29 @@ gemini extensions install https://github.com/explorium-ai/vibeprospecting-mcp
 
 The extension is loaded and managed automatically by Gemini CLI, and OAuth sign-in is handled on first use. See the [Gemini CLI extensions docs](https://geminicli.com/docs/extensions/) for details.
 
+### Hermes
+
+Hermes uses the same remote endpoint, but its CLI needs the server written to config plus an explicit OAuth login. Run these in your terminal:
+
+1. **Register the server** — set it in config directly (more reliable than `hermes mcp add`, which can try to authenticate before the entry is saved):
+
+   ```bash
+   hermes config set mcp_servers.vibe_prospecting.url "https://vibeprospecting.explorium.ai/mcp"
+   hermes config set mcp_servers.vibe_prospecting.auth oauth
+   ```
+
+2. **Sign in** — opens your browser to authenticate:
+
+   ```bash
+   hermes mcp login vibe_prospecting
+   ```
+
+   On a **remote, SSH, or Docker** host, the browser can't reach the local callback after you approve — that's expected. Copy the **full URL** from the address bar and paste it back at the Hermes prompt.
+
+3. **Verify & use** — `hermes mcp list` should show `vibe_prospecting` as authenticated. Start a new chat so the `mcp_vibe_prospecting_*` tools load, then try a prompt from [Examples](#examples). To get a CSV, ask Hermes to **"export and download"** (exports return a link, not the file itself).
+
+> **Connection drops on the first call?** The default MCP discovery timeout is too short for the OAuth handshake — raise it: `hermes config set mcp_discovery_timeout 10`.
+
 ---
 
 ## Examples
@@ -117,7 +140,7 @@ the decision-makers and export the list to CSV.
 
 - **`Failed to connect` / error `-32000` in Claude Code** — this happens with the old local `uvx vibeprospecting-mcp` (stdio) command. That path is **deprecated**; use the `--transport http` command above instead.
 - **Connector won't connect in Cowork/Desktop** — the server is reached from Anthropic's cloud, so the URL must be publicly reachable. Double-check the URL is exactly `https://vibeprospecting.explorium.ai/mcp`.
-- **Re-authenticate** — in Claude Code run `claude mcp remove vibe-prospecting` then re-add it; in Codex run `codex mcp login vibe-prospecting` again.
+- **Re-authenticate** — in Claude Code run `claude mcp remove vibe-prospecting` then re-add it; in Codex run `codex mcp login vibe-prospecting` again; in Hermes run `hermes mcp login vibe_prospecting` again.
 
 ---
 


### PR DESCRIPTION
## What

Adds a **Hermes** section to the README Installation guide, covering how to connect Vibe Prospecting to the [Hermes Agent](https://hermes-agent.nousresearch.com) CLI.

## Why

Hermes loads remote MCP servers from its own `config.yaml` (`mcp_servers` key) with OAuth 2.1, but the flow differs from Claude Code / Codex / Gemini enough to need its own steps — config must be written before login, and OAuth uses a loopback callback that breaks on remote/SSH/Docker hosts.

## Changes (`README.md`)

- New **### Hermes** install section:
  - Register the server via `hermes config set mcp_servers.vibe_prospecting.{url,auth}` (more reliable than `hermes mcp add`).
  - `hermes mcp login vibe_prospecting` for OAuth, with the remote/SSH/Docker paste-back-URL caveat.
  - Verify with `hermes mcp list`; note the `mcp_vibe_prospecting_*` tool prefix and the "export and download" CSV behavior.
  - Troubleshooting note to raise `mcp_discovery_timeout` if the first call drops during the OAuth handshake.
- Added Hermes re-authenticate command to the Troubleshooting section.

Docs-only change; no server code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)